### PR TITLE
Add baisc tests for strategies in forked scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@pika/plugin-ts-standard-pkg": "^0.9.2",
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/jest": "^26.0.19",
-    "effector": "^21.8.2",
+    "effector": "^21.8.11",
     "jest": "^26.6.3",
     "pika-plugin-package.json": "^1.0.2",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@pika/plugin-ts-standard-pkg": "^0.9.2",
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/jest": "^26.0.19",
-    "effector": "^21.2.0",
+    "effector": "^21.8.2",
     "jest": "^26.6.3",
     "pika-plugin-package.json": "^1.0.2",
     "prettier": "^2.2.1",

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -260,7 +260,7 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
   `)
 })
 
-test('createReEffect in scope: failed reeffect does not hanging up `allSettled`', async () => {
+test('createReEffect in scope: failed reeffect does not hanging up `allSettled` and resolves in scope correctly', async () => {
   const fail = jest.fn()
 
   const app = createDomain()
@@ -283,6 +283,7 @@ test('createReEffect in scope: failed reeffect does not hanging up `allSettled`'
   })
 
   $store.on(reeffect.done, (state, { result }) => state + result)
+  $store.on(reeffect.fail, () => -1)
 
   const scope = fork(app)
 
@@ -295,7 +296,7 @@ test('createReEffect in scope: failed reeffect does not hanging up `allSettled`'
 
   expect(serialize(scope)).toMatchInlineSnapshot(`
     Object {
-      "$store": 0,
+      "$store": -1,
     }
   `)
 })

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -152,7 +152,7 @@ test('async createReEffect resolves in scope with scopeBind', async () => {
     async handler(p) {
       await new Promise(r => setTimeout(r, 300))
 
-      return Promise.resolve(p);
+      return Promise.resolve(p)
     },
   })
 
@@ -222,19 +222,21 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
     async handler(p) {
       await new Promise(r => setTimeout(r, 900))
 
-      return Promise.resolve(p);
+      return Promise.resolve(p)
     },
   })
-  const delayFx = app.createEffect<number, number>(async (t) => new Promise(r => setTimeout(() => r(t), t)));
+  const delayFx = app.createEffect<number, number>(
+    async t => new Promise(r => setTimeout(() => r(t), t))
+  )
 
   forward({
     from: start,
-    to: delayFx.prepend(() => 250)
+    to: delayFx.prepend(() => 250),
   })
 
   forward({
     from: delayFx.done,
-    to: reeffect.cancel
+    to: reeffect.cancel,
   })
 
   start.watch(() => {
@@ -269,9 +271,7 @@ test('createReEffect in scope: multiple calls aren`t hanging up `allSettled`', a
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect({
     async handler() {
-      return new Promise<number>(resolve =>
-        setTimeout(() => resolve(5), 300)
-      )
+      return new Promise<number>(resolve => setTimeout(() => resolve(5), 300))
     },
   })
 
@@ -279,17 +279,17 @@ test('createReEffect in scope: multiple calls aren`t hanging up `allSettled`', a
 
   forward({
     from: start,
-    to: reeffect
+    to: reeffect,
   })
 
   forward({
     from: start,
-    to: secondTrigger
+    to: secondTrigger,
   })
 
   forward({
     from: secondTrigger,
-    to: reeffect
+    to: reeffect,
   })
 
   $store.on(reeffect.done, (state, { result }) => state + result)
@@ -319,9 +319,7 @@ test('createReEffect in scope: TAKE_EVERY', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve =>
-        setTimeout(() => resolve(p), 300)
-      )
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
     },
   })
 
@@ -362,9 +360,7 @@ test('createReEffect in scope: TAKE_FIRST', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve =>
-        setTimeout(() => resolve(p), 300)
-      )
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
     },
     strategy: TAKE_FIRST,
   })
@@ -406,9 +402,7 @@ test('createReEffect in scope: TAKE_LAST', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve =>
-        setTimeout(() => resolve(p), 300)
-      )
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
     },
     strategy: TAKE_LAST,
   })
@@ -450,9 +444,7 @@ test('createReEffect in scope: QUEUE', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve =>
-        setTimeout(() => resolve(p), 300)
-      )
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
     },
     strategy: QUEUE,
   })

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -1,7 +1,7 @@
-import { createDomain, forward } from 'effector'
+import { createDomain, forward, scopeBind } from 'effector'
 import { fork, serialize, allSettled } from 'effector/fork'
 import { createReEffectFactory } from './createReEffect'
-import { TAKE_EVERY } from './strategy'
+import { TAKE_FIRST, TAKE_LAST, QUEUE, RACE } from './strategy'
 
 test('createReEffect resolves in fork by default', async () => {
   const createReEffect = createReEffectFactory()
@@ -110,45 +110,24 @@ test('createReEffect in fork do not affect domain', async () => {
   expect($store.getState()).toMatchInlineSnapshot(`0`)
 })
 
-test('createReEffect in fork: TAKE_EVERY works', async () => {
-  expect.assertions(1)
-  const strategy = TAKE_EVERY
-
+test('createReEffect resolves in scope with scopeBind', async () => {
   const app = createDomain()
   const createReEffect = createReEffectFactory(app.createEffect)
   const start = app.createEvent()
-  const triggerOne = app.createEvent()
-  const triggerTwo = app.createEvent()
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
-  const reeffect = createReEffect({
-    handler() {
-
-      return Promise.resolve(2);
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return p
     },
-    strategy
+  })
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(5)
   })
 
   $store.on(reeffect.done, (state, { result }) => state + result)
-
-  forward({
-    from: triggerOne,
-    to: reeffect
-  })
-
-  forward({
-    from: triggerTwo,
-    to: reeffect
-  })
-
-  forward({
-    from: triggerOne,
-    to: triggerTwo,
-  })
-
-  forward({
-    from: start,
-    to: triggerOne
-  });
 
   const scope = fork(app)
 
@@ -159,7 +138,349 @@ test('createReEffect in fork: TAKE_EVERY works', async () => {
 
   expect(serialize(scope)).toMatchInlineSnapshot(`
     Object {
-      "$store": 2,
+      "$store": 5,
+    }
+  `)
+})
+
+test('async createReEffect resolves in scope with scopeBind', async () => {
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      await new Promise(r => setTimeout(r, 300))
+
+      return Promise.resolve(p);
+    },
+  })
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(5)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect resolves in scope when called as `inner effect`', async () => {
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return p
+    },
+  })
+  const effect = app.createEffect(async () => {
+    await reeffect(5)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  forward({
+    from: start,
+    to: effect,
+  })
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: multiple calls aren`t hanging up `allSettled`', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const secondTrigger = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect({
+    async handler() {
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(5), 300)
+      )
+    },
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  forward({
+    from: start,
+    to: reeffect
+  })
+
+  forward({
+    from: start,
+    to: secondTrigger
+  })
+
+  forward({
+    from: secondTrigger,
+    to: reeffect
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: TAKE_EVERY', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(p), 300)
+      )
+    },
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(1)
+    bindReeffect(2)
+    bindReeffect(5)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: TAKE_FIRST', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(p), 300)
+      )
+    },
+    strategy: TAKE_FIRST,
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(5)
+    bindReeffect(2)
+    bindReeffect(3)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: TAKE_LAST', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(p), 300)
+      )
+    },
+    strategy: TAKE_LAST,
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(5)
+    bindReeffect(2)
+    bindReeffect(5)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: QUEUE', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(p), 300)
+      )
+    },
+    strategy: QUEUE,
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(1)
+    bindReeffect(2)
+    bindReeffect(3)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
+    }
+  `)
+})
+
+test('createReEffect in scope: RACE', async () => {
+  const cancelled = jest.fn()
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect<number, number>({
+    async handler(p) {
+      const timeout = p === 5 ? 100 : 600
+
+      return new Promise<number>(resolve =>
+        setTimeout(() => resolve(p), timeout)
+      )
+    },
+    strategy: RACE,
+  })
+
+  reeffect.cancelled.watch(cancelled)
+
+  start.watch(() => {
+    const bindReeffect = scopeBind(reeffect)
+
+    bindReeffect(2)
+    bindReeffect(2)
+    bindReeffect(5)
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(cancelled).toBeCalledTimes(2)
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 5,
     }
   `)
 })

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -235,14 +235,13 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
   })
 
   forward({
-    from: delayFx.done,
-    to: reeffect.cancel,
+    from: start,
+    to: reeffect.prepend(() => 5),
   })
 
-  start.watch(() => {
-    const bindReeffect = scopeBind(reeffect)
-
-    bindReeffect(5)
+  forward({
+    from: delayFx.done,
+    to: reeffect.cancel,
   })
 
   $store.on(reeffect.done, (state, { result }) => state + result)

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -1,6 +1,7 @@
 import { createDomain, forward } from 'effector'
 import { fork, serialize, allSettled } from 'effector/fork'
 import { createReEffectFactory } from './createReEffect'
+import { TAKE_EVERY } from './strategy'
 
 test('createReEffect resolves in fork by default', async () => {
   const createReEffect = createReEffectFactory()
@@ -107,4 +108,58 @@ test('createReEffect in fork do not affect domain', async () => {
   })
 
   expect($store.getState()).toMatchInlineSnapshot(`0`)
+})
+
+test('createReEffect in fork: TAKE_EVERY works', async () => {
+  expect.assertions(1)
+  const strategy = TAKE_EVERY
+
+  const app = createDomain()
+  const createReEffect = createReEffectFactory(app.createEffect)
+  const start = app.createEvent()
+  const triggerOne = app.createEvent()
+  const triggerTwo = app.createEvent()
+  const $store = app.createStore(0, { name: '$store', sid: '$store' })
+  const reeffect = createReEffect({
+    handler() {
+
+      return Promise.resolve(2);
+    },
+    strategy
+  })
+
+  $store.on(reeffect.done, (state, { result }) => state + result)
+
+  forward({
+    from: triggerOne,
+    to: reeffect
+  })
+
+  forward({
+    from: triggerTwo,
+    to: reeffect
+  })
+
+  forward({
+    from: triggerOne,
+    to: triggerTwo,
+  })
+
+  forward({
+    from: start,
+    to: triggerOne
+  });
+
+  const scope = fork(app)
+
+  await allSettled(start, {
+    scope,
+    params: undefined,
+  })
+
+  expect(serialize(scope)).toMatchInlineSnapshot(`
+    Object {
+      "$store": 2,
+    }
+  `)
 })

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -116,7 +116,7 @@ test('createReEffect resolves in scope with scopeBind', async () => {
   const start = app.createEvent()
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
-    async handler(p) {
+    handler(p) {
       return p
     },
   })
@@ -150,9 +150,7 @@ test('async createReEffect resolves in scope with scopeBind', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      await new Promise(r => setTimeout(r, 300))
-
-      return Promise.resolve(p)
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
   })
 
@@ -185,7 +183,7 @@ test('createReEffect resolves in scope when called as `inner effect`', async () 
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return p
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
   })
   const effect = app.createEffect(async () => {
@@ -220,7 +218,7 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      await new Promise(r => setTimeout(r, 900))
+      await new Promise(r => setTimeout(r, 50))
 
       return Promise.resolve(p)
     },
@@ -231,7 +229,7 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
 
   forward({
     from: start,
-    to: delayFx.prepend(() => 250),
+    to: delayFx.prepend(() => 25),
   })
 
   forward({
@@ -255,7 +253,7 @@ test('createReEffect in scope: cancelled reeffect does not hanging up `allSettle
 
   expect(serialize(scope)).toMatchInlineSnapshot(`
     Object {
-      "$store": 5,
+      "$store": 0,
     }
   `)
 })
@@ -269,7 +267,7 @@ test('createReEffect in scope: failed reeffect does not hanging up `allSettled` 
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler() {
-      await new Promise(r => setTimeout(r, 900))
+      await new Promise(r => setTimeout(r, 30))
 
       throw new Error('failed!')
     },
@@ -311,7 +309,7 @@ test('createReEffect in scope: multiple calls aren`t hanging up `allSettled`', a
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect({
     async handler() {
-      return new Promise<number>(resolve => setTimeout(() => resolve(5), 300))
+      return new Promise<number>(resolve => setTimeout(() => resolve(5), 30))
     },
   })
 
@@ -359,7 +357,7 @@ test('createReEffect in scope: TAKE_EVERY', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
   })
 
@@ -400,7 +398,7 @@ test('createReEffect in scope: TAKE_FIRST', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
     strategy: TAKE_FIRST,
   })
@@ -442,7 +440,7 @@ test('createReEffect in scope: TAKE_LAST', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
     strategy: TAKE_LAST,
   })
@@ -484,7 +482,7 @@ test('createReEffect in scope: QUEUE', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      return new Promise<number>(resolve => setTimeout(() => resolve(p), 300))
+      return new Promise<number>(resolve => setTimeout(() => resolve(p), 30))
     },
     strategy: QUEUE,
   })
@@ -526,7 +524,7 @@ test('createReEffect in scope: RACE', async () => {
   const $store = app.createStore(0, { name: '$store', sid: '$store' })
   const reeffect = createReEffect<number, number>({
     async handler(p) {
-      const timeout = p === 5 ? 100 : 600
+      const timeout = p === 5 ? 10 : 20
 
       return new Promise<number>(resolve =>
         setTimeout(() => resolve(p), timeout)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,10 +3261,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effector@^21.2.0:
-  version "21.7.5"
-  resolved "https://registry.yarnpkg.com/effector/-/effector-21.7.5.tgz#6a8ed81c57e17cc8373ce29645e2715f9693aebd"
-  integrity sha512-sWB9xPJxfTHsPOzjxUIa2rJQ1T33Ya4X2N8RSqm+XMewEt5YmPpo2w82yZF27JxBl0qAQBg1ZI3Tz7u5fE+cwA==
+effector@^21.8.2:
+  version "21.8.2"
+  resolved "https://registry.yarnpkg.com/effector/-/effector-21.8.2.tgz#2c430039011ffdb3919283af07cc823d2d8cd0ed"
+  integrity sha512-xt+fsPsCfJ3pDkwTj5xsvsohJRVsNDbuxcgZL2wkuRYat7PaFLP3DkwMDqaP1dtjgD5LJJ4UAlKEwar8ImgPgQ==
 
 ejs@^2.6.1:
   version "2.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,10 +3261,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effector@^21.8.2:
-  version "21.8.2"
-  resolved "https://registry.yarnpkg.com/effector/-/effector-21.8.2.tgz#2c430039011ffdb3919283af07cc823d2d8cd0ed"
-  integrity sha512-xt+fsPsCfJ3pDkwTj5xsvsohJRVsNDbuxcgZL2wkuRYat7PaFLP3DkwMDqaP1dtjgD5LJJ4UAlKEwar8ImgPgQ==
+effector@^21.8.11:
+  version "21.8.11"
+  resolved "https://registry.yarnpkg.com/effector/-/effector-21.8.11.tgz#fbe35fb754a9918fb33781a9a408b635218ff41a"
+  integrity sha512-yEdPMYsocx5rZb/zvnPrkM77tpbnTqWZ/W/JYWxojhUD+ZW04Mpa8ezL0X1LwceYnTHAj2RscLCKK9IFD85lcA==
 
 ejs@^2.6.1:
   version "2.7.4"


### PR DESCRIPTION
Hello, @yumauri!

I have added very basic tests to check ReEffects and fork compatibility (issue #6)

And apparently ReEffects are not very compatible with fork, as for now:
1. When multiple ReEffect calls are happened, `await allSettled` just hangs up forever, for all strategies.
2. Imperative ReEffect call inside basic effector's Effect does not resolves to scope, like basic Effect [does](https://effector.dev/docs/api/effector/scope#imperative-effects-calls-with-scope)

Good news: ReEffect is compatible with [scopeBind](https://effector.dev/docs/api/effector/scopeBind#scopebind) and resolves in scope, when called this way from `watch`

On the first problem: Looks like cancelled ReEffects are not "caught" by `allSettled` and it keeps waiting for them to finish

I have added separate test for that, with one cancelled (via `.cancel` event) ReEffect and this test case fails the same way, as with strategies - `allSettled` just never finishes.

Failed ReEffect does not hangs `allSettled` though and resolves in scope correctly
