### PR TITLE
Fixed compatibility with effector@22.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ yarn-error.log
 .DS_Store
 .project
 .vscode
+.idea
 *.log

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@pika/plugin-ts-standard-pkg": "^0.9.2",
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/jest": "^26.0.19",
-    "effector": "^21.8.11",
+    "effector": "~22.0.6",
     "jest": "^26.6.3",
     "pika-plugin-package.json": "^1.0.2",
     "prettier": "^2.2.1",
@@ -85,7 +85,7 @@
     "yaspeller": "^7.0.0"
   },
   "peerDependencies": {
-    "effector": "^21.2.0"
+    "effector": "~22.0.6"
   },
   "engines": {
     "node": ">=10.17.0"

--- a/src/createReEffect.ts
+++ b/src/createReEffect.ts
@@ -1,6 +1,7 @@
 import { createEffect as effectorCreateEffect, createEvent } from 'effector'
 import { CreateReEffect, CreateReEffectConfig, ReEffect } from './types'
 import { CancellablePromise } from './promise'
+import { getGraph } from './tools'
 import { patchInstance } from './instance'
 import { patchRunner } from './runner'
 import { Strategy, TAKE_EVERY } from './strategy'
@@ -37,7 +38,9 @@ export const createReEffectFactory = (
     cancelled,
     cancel,
     running,
+    finally: instance.finally,
     inFlight: instance.inFlight,
+    getHandler: instance.use.getCurrent,
 
     push: (promise: CancellablePromise<Done>) => running.push(promise),
     unpush: (promise?: CancellablePromise<Done>) => {
@@ -52,7 +55,10 @@ export const createReEffectFactory = (
       running.map(promise => promise.cancel(strategy)),
   }
 
-  patchRunner<Payload, Done, Fail>(instance.graphite.scope.runner, scope as any)
+  patchRunner<Payload, Done, Fail>(
+    getGraph(instance).scope.runner,
+    scope as any
+  )
   patchInstance<Payload, Done, Fail>(instance, scope)
   return instance
 }

--- a/src/fork.spec.ts
+++ b/src/fork.spec.ts
@@ -1,7 +1,16 @@
-import { createDomain, forward, scopeBind } from 'effector'
-import { fork, serialize, allSettled } from 'effector/fork'
+import {
+  allSettled,
+  createDomain,
+  fork,
+  forward,
+  scopeBind as effectorScopeBind,
+  serialize,
+} from 'effector'
 import { createReEffectFactory } from './createReEffect'
-import { TAKE_FIRST, TAKE_LAST, QUEUE, RACE } from './strategy'
+import { QUEUE, RACE, TAKE_FIRST, TAKE_LAST } from './strategy'
+
+// TODO: scopeBind doesn't support ReEffect as argument
+const scopeBind = effectorScopeBind as any
 
 test('createReEffect resolves in fork by default', async () => {
   const createReEffect = createReEffectFactory()

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,11 +1,11 @@
-import { Event, launch, Step, step } from 'effector'
+import { Event, launch, Node, step } from 'effector'
 import { CancelledPayload, MutableReEffect, ReEffectConfig } from './types'
 import { defer } from './promise'
 import { assign, own } from './tools'
 
 interface InstanceNewEvents<Payload> {
-  readonly cancelled: Event<CancelledPayload<Payload>> & { graphite: Step }
-  readonly cancel: Event<void> & { graphite: Step }
+  readonly cancelled: Event<CancelledPayload<Payload>> & { graphite: Node }
+  readonly cancel: Event<void> & { graphite: Node }
   readonly feedback: boolean
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,4 @@
-import { createNode, Event, launch, step, Step, Store } from 'effector'
+import { createNode, Event, launch, Node, step, Store } from 'effector'
 import { CancelledError, LimitExceededError, ReEffectError } from './error'
 import { QUEUE, RACE, Strategy, TAKE_FIRST, TAKE_LAST } from './strategy'
 import { cancellable, CancellablePromise, defer } from './promise'
@@ -40,11 +40,10 @@ const enum Result {
  * Patch runner, add new events and replace step sequence
  */
 export const patchRunner = <Payload, Done, Fail>(
-  runner: Step,
+  runner: Node,
   scope: RunnerScope<Payload, Done, Fail>
 ) => {
   assign(runner.scope, scope)
-  runner.meta.onCopy.push('cancelled', 'cancel')
   runner.seq = seq<Payload, Done, Fail>()
 
   // make `cancel` event work
@@ -193,7 +192,7 @@ const fin = <Payload>(
   fn: (data: any) => void
 ) => (promise?: CancellablePromise<any>) => (data: any) => {
   const runningCount = unpush(promise)
-  const targets: (Event<any> | Store<number> | Step)[] = [inFlight, sidechain]
+  const targets: (Event<any> | Store<number> | Node)[] = [inFlight, sidechain]
   const payloads: any[] = [runningCount, [fn, data]]
 
   // - if this is `cancelled` event

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,4 @@
-import { Step } from 'effector'
+import { Node } from 'effector'
 
 /**
  * Shortcut for smaller bundle size
@@ -7,15 +7,20 @@ export const assign = Object.assign
 
 /**
  * Helper from Effector's code, to add family links
- * https://github.com/zerobias/effector/blob/master/src/effector/stdlib/family.js
+ * https://github.com/effector/effector/blob/master/src/effector/own.ts
  */
-export const own = (
-  { graphite: owner }: { graphite: Step },
-  links: { graphite: Step }[]
-) => {
-  for (const { graphite } of links) {
-    graphite.family.type = 'crosslink'
-    graphite.family.owners.push(owner)
-    owner.family.links.push(graphite)
+export const own = (instance: any, links: { graphite: Node }[]) => {
+  const owner = getGraph(instance)
+
+  for (const _link of links) {
+    const link = getGraph(_link)
+    if (owner.family.type !== 'domain') link.family.type = 'crosslink'
+    link.family.owners.push(owner)
+    owner.family.links.push(link)
   }
 }
+
+/**
+ * https://github.com/effector/effector/blob/master/src/effector/getter.ts
+ */
+export const getGraph = (graph: any): Node => graph.graphite || graph

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Effect, Event, Step } from 'effector'
+import { Effect, Event, Node } from 'effector'
 import { ReEffectError } from './error'
 import { Strategy } from './strategy'
 
@@ -47,7 +47,7 @@ export interface MutableReEffect<Payload, Done, Fail = Error>
     CallableReEffect<Payload, Done>,
     Mutable<ReEffect<Payload, Done, Fail>>
 {
-  graphite: Step,
+  graphite: Node,
   create: (
     paramsOrConfig: Payload | ReEffectConfig<Payload> | undefined,
     [maybeStrategyOrConfig]: [ReEffectConfig<Payload> | Strategy | undefined]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8446,9 +8446,9 @@ tmp@^0.0.33:
     os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,10 +3261,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effector@^21.8.11:
-  version "21.8.11"
-  resolved "https://registry.yarnpkg.com/effector/-/effector-21.8.11.tgz#fbe35fb754a9918fb33781a9a408b635218ff41a"
-  integrity sha512-yEdPMYsocx5rZb/zvnPrkM77tpbnTqWZ/W/JYWxojhUD+ZW04Mpa8ezL0X1LwceYnTHAj2RscLCKK9IFD85lcA==
+effector@~22.0.6:
+  version "22.0.6"
+  resolved "https://registry.yarnpkg.com/effector/-/effector-22.0.6.tgz#5f43a6b7b92e44eb4cc507e6d0ab3fe1f5dec676"
+  integrity sha512-3HQ5RdGX6QOdASmaVhp3BizMj4Ca0ehhYWhTr8Bb1q7Pr2zvgfyWhy7jiIkItYz8MYiCBj4p8e3uKGXAiVcAAQ==
 
 ejs@^2.6.1:
   version "2.7.4"


### PR DESCRIPTION
There are some minor fixes that are compatible with old `^21.8.11` and with new `~22.0.6`. Only `fork.spec.ts` results with more failed tests, but as I can see it's not crucial. Also I've tried to fix compatibilty with `~22.1.0` but there are some internal changes in `createUnit` that I can't understand so far.

**Breaking changes in `22.0.0`:** commit `c0f8c9d6308b53635714ac22509602f022b5b254` file `createEffect.ts`

**Breaking changes in `22.1.1`:** commit `f166f7f53ac7f269ddaee5aae06aa760a7f13d0d ` file `createUnit.ts` line `340`. If this line is removed, everything works fine.